### PR TITLE
ecs-web - Breaking change: In preparation for moving cache resources out of ecs-web module

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,6 +22,8 @@ lint:
     - markdownlint@0.39.0
     - prettier@3.2.5
     - terrascan@1.18.11
+    - terraform@1.7.4:
+        commands: [validate, fmt]
     - tflint@0.50.3
     - trivy@0.49.1
     - trufflehog@3.67.5

--- a/modules/app-cache-dynamodb/context.tf
+++ b/modules/app-cache-dynamodb/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/app-cache-dynamodb/main.tf
+++ b/modules/app-cache-dynamodb/main.tf
@@ -1,0 +1,52 @@
+module "dynamodb_label" {
+  source     = "cloudposse/label/null"
+  version    = "0.25.0"
+  attributes = ["dynamodb"]
+  context    = module.this.context
+}
+
+module "dynamodb" {
+  source  = "cloudposse/dynamodb/aws"
+  version = "0.35.0"
+
+  hash_key                      = "key"
+  enable_autoscaler             = false
+  enable_point_in_time_recovery = false
+  billing_mode                  = "PAY_PER_REQUEST"
+  ttl_attribute                 = var.dynamodb_cache_ttl_attribute
+
+  context = module.dynamodb_label.context
+}
+
+data "aws_iam_policy_document" "dynamodb" {
+  # Allow ECS task to access DynamoDB cache table
+  statement {
+    sid = ""
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchGetItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:UpdateItem"
+    ]
+
+    resources = [
+      module.dynamodb.table_arn
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "dynamodb_access_policy" {
+  name        = module.dynamodb_label.id
+  path        = "/"
+  description = "Allows access to DynamoDB table for app cache"
+  policy      = data.aws_iam_policy_document.dynamodb.json
+}

--- a/modules/app-cache-dynamodb/outputs.tf
+++ b/modules/app-cache-dynamodb/outputs.tf
@@ -1,0 +1,14 @@
+output "table_name" {
+  value       = module.dynamodb.table_name
+  description = "DynamoDB table name for app cache"
+}
+
+output "table_arn" {
+  value       = module.dynamodb.table_arn
+  description = "DynamoDB table ARN"
+}
+
+output "access_policy_arn" {
+  value       = aws_iam_policy.dynamodb_access_policy.arn
+  description = "Policy to allow access to DynamoDB table for app cache"
+}

--- a/modules/app-cache-dynamodb/variables.tf
+++ b/modules/app-cache-dynamodb/variables.tf
@@ -1,0 +1,5 @@
+variable "dynamodb_cache_ttl_attribute" {
+  type        = string
+  default     = "expires_at"
+  description = "DynamoDB table TTL attribute"
+}

--- a/modules/app-cache-dynamodb/versions.tf
+++ b/modules/app-cache-dynamodb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.59"
+    }
+  }
+}

--- a/modules/app-cache-memcached/context.tf
+++ b/modules/app-cache-memcached/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/app-cache-memcached/main.tf
+++ b/modules/app-cache-memcached/main.tf
@@ -1,0 +1,59 @@
+module "memcached_label" {
+  source     = "cloudposse/label/null"
+  version    = "0.25.0"
+  attributes = ["memcached"]
+  context    = module.this.context
+}
+
+module "memcached" {
+  source  = "cloudposse/elasticache-memcached/aws"
+  version = "0.19.0"
+
+  // Networking
+  vpc_id                  = var.vpc_id
+  subnets                 = var.subnet_ids
+  availability_zones      = var.availability_zones
+  availability_zone       = var.az_mode == "single-az" ?  one(var.availability_zones) : null
+  allowed_security_groups = [module.memcached_allowed_sg.id]
+
+  // DNS
+  zone_id       = var.zone_id
+  dns_subdomain = var.dns_subdomain
+
+  // Memcached infra & HA
+  az_mode       = var.az_mode
+  cluster_size  = var.cluster_size
+  instance_type = var.instance_type
+  maintenance_window = var.maintenance_window
+
+  // Memcached settings    
+  engine_version                     = var.engine_version
+  apply_immediately                  = true
+  elasticache_parameter_group_family = var.elasticache_parameter_group_family
+  max_item_size                      = var.max_item_size
+  transit_encryption_enabled = var.transit_encryption_enabled
+
+  context = module.memcached_label.context
+}
+
+# Security group which is allowed access to memcached
+# This can be assigned to other resources, such as the ECS task
+module "memcached_allowed_sg" {
+  source  = "cloudposse/security-group/aws"
+  version = "2.2.0"
+
+  attributes = ["allowed"]
+
+  security_group_description = "Services which need memcached access can be assigned this security group"
+
+  create_before_destroy = true
+
+  # Allow unlimited egress
+  allow_all_egress = true
+
+  rules = []
+
+  vpc_id = var.vpc_id
+
+  context = module.memcached_label.context
+}

--- a/modules/app-cache-memcached/outputs.tf
+++ b/modules/app-cache-memcached/outputs.tf
@@ -1,0 +1,24 @@
+output "endpoint" {
+  value       = module.memcached.cluster_configuration_endpoint
+  description = "Elasticache memcached endpoint"
+}
+
+output "hostname" {
+  value       = module.memcached.hostname
+  description = "Cluster hostname"
+}
+
+# output "port" {
+#   value       = module.memcached.port
+#   description = "memcached port"
+# }
+
+output "security_group_id" {
+  value       = module.memcached.security_group_id
+  description = "Elasticache memcached security group ID - allows access to memcached cache"
+}
+
+output "access_security_group_id" {
+  value       = module.memcached_allowed_sg.id
+  description = "ID of the security group for use by services which need access to memcached"
+}

--- a/modules/app-cache-memcached/variables.tf
+++ b/modules/app-cache-memcached/variables.tf
@@ -1,0 +1,94 @@
+// Networking
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  default     = []
+  description = "List of Availability Zones for the cluster. If az_mode is single-az, the first value will be used."
+}
+
+variable "allowed_security_groups" {
+  type        = list(string)
+  default     = []
+  description = "List of Security Group IDs that are allowed ingress to the cluster's Security Group created in the module"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of (private) subnet IDs"
+}
+
+// DNS
+
+variable "zone_id" {
+  type        = string
+  description = "Main Route 53 hosted zone ID."
+  default     = ""
+}
+
+variable "dns_subdomain" {
+  type        = string
+  default     = ""
+  description = "The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name."
+}
+
+// memcached infra
+
+variable "cluster_size" {
+  type        = number
+  default     = 1
+  description = "Number of nodes in cluster. Must be > 1 and == number of AZ's when az_mode is cross-az."
+}
+
+variable "az_mode" {
+  type        = string
+  default     = "single-az"
+  description = "Enable or disable multiple AZs, eg: single-az or cross-az"
+
+  validation {
+    condition     = var.az_mode == "single-az" || var.az_mode == "cross-az"
+    error_message = "az_mode value must be either single-az or cross-az"
+  }
+}
+
+# https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html
+variable "instance_type" {
+  type        = string
+  default     = "cache.t4g.micro"
+  description = "Elasticache instance type"
+}
+
+// memcached settings
+
+variable "engine_version" {
+  type        = string
+  default     = "1.6.22"
+  description = "memcached engine version"
+}
+
+variable "elasticache_parameter_group_family" {
+  type        = string
+  description = "ElastiCache parameter group family"
+  default     = "memcached1.6"
+}
+
+variable "max_item_size" {
+  type        = number
+  default     = 10485760
+  description = "Max item size"
+}
+
+variable "maintenance_window" {
+  type        = string
+  default     = "sun:13:00-sun:14:00"
+  description = "Maintenance window"
+}
+
+variable "transit_encryption_enabled" {
+  type        = bool
+  description = "Boolean flag to enable transit encryption (requires Memcached version 1.6.12+)"
+  default     = true
+}

--- a/modules/app-cache-memcached/versions.tf
+++ b/modules/app-cache-memcached/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/modules/app-cache-redis/context.tf
+++ b/modules/app-cache-redis/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/app-cache-redis/main.tf
+++ b/modules/app-cache-redis/main.tf
@@ -1,0 +1,62 @@
+module "redis_label" {
+  source     = "cloudposse/label/null"
+  version    = "0.25.0"
+  attributes = ["redis", "cache"]
+  context    = module.this.context
+}
+
+module "redis" {
+  source  = "cloudposse/elasticache-redis/aws"
+  version = "1.2.1"
+
+  # Networking
+  availability_zones = var.availability_zones
+  vpc_id             = var.vpc_id
+  subnets            = var.subnet_ids
+
+  # DNS
+  zone_id       = var.zone_id
+  dns_subdomain = var.dns_subdomain
+
+  # Security groups
+  create_security_group      = true
+  allowed_security_group_ids = [module.redis_allowed_sg.id]
+
+  # Redis infra
+  cluster_mode_enabled       = var.cluster_mode_enabled
+  cluster_size               = var.cluster_size
+  instance_type              = var.instance_type
+  apply_immediately          = true
+  automatic_failover_enabled = false
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  # Redis settings
+  engine_version = var.engine_version
+  family         = var.family
+  auth_token     = var.password
+
+  context = module.redis_label.context
+}
+
+# Security group which is allowed access to redis
+# This can be assigned to other resources, such as the ECS task
+module "redis_allowed_sg" {
+  source  = "cloudposse/security-group/aws"
+  version = "2.2.0"
+
+  attributes = ["allowed"]
+
+  security_group_description = "Services which need Redis access can be assigned this security group"
+
+  create_before_destroy = true
+
+  # Allow unlimited egress
+  allow_all_egress = true
+
+  rules = []
+
+  vpc_id = var.vpc_id
+
+  context = module.redis_label.context
+}

--- a/modules/app-cache-redis/outputs.tf
+++ b/modules/app-cache-redis/outputs.tf
@@ -1,0 +1,19 @@
+output "endpoint" {
+  value       = module.redis.endpoint
+  description = "Elasticache Redis endpoint"
+}
+
+output "port" {
+  value       = module.redis.port
+  description = "Redis port"
+}
+
+output "security_group_id" {
+  value       = module.redis.security_group_id
+  description = "Elasticache Redis security group ID - allows access to Redis cache"
+}
+
+output "access_security_group_id" {
+  value       = module.redis_allowed_sg.id
+  description = "ID of the security group for use by services which need access to Redis"
+}

--- a/modules/app-cache-redis/variables.tf
+++ b/modules/app-cache-redis/variables.tf
@@ -1,0 +1,78 @@
+// Networking
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zone IDs - relevant when multi-AZ is enabled"
+  default     = []
+}
+
+variable "allowed_security_groups" {
+  type        = list(string)
+  default     = []
+  description = "List of Security Group IDs that are allowed ingress to the cluster's Security Group created in the module"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of (private) subnet IDs"
+}
+
+// DNS
+
+variable "zone_id" {
+  type        = string
+  description = "Main Route 53 hosted zone ID."
+  default     = ""
+}
+
+variable "dns_subdomain" {
+  type        = string
+  default     = ""
+  description = "The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name."
+}
+
+// Redis infra
+
+variable "cluster_mode_enabled" {
+  type        = bool
+  description = "Flag to enable/disable creation of a native redis cluster. `automatic_failover_enabled` must be set to `true`. Only 1 `cluster_mode` block is allowed"
+  default     = false
+}
+
+variable "cluster_size" {
+  type        = number
+  default     = 1
+  description = "Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`*"
+}
+
+# https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+variable "instance_type" {
+  type        = string
+  default     = "cache.t4g.micro"
+  description = "Elastic cache instance type"
+}
+
+// Redis settings
+
+variable "family" {
+  type        = string
+  default     = "redis6.x"
+  description = "Redis family"
+}
+
+variable "engine_version" {
+  type        = string
+  default     = "6.2"
+  description = "Redis engine version"
+}
+
+variable "password" {
+  type        = string
+  description = "Auth token for password protecting redis, `transit_encryption_enabled` must be set to `true`. Password must be longer than 16 chars"
+  default     = null
+
+}

--- a/modules/app-cache-redis/versions.tf
+++ b/modules/app-cache-redis/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.18"
+    }
+  }
+}

--- a/modules/ecs-background/main.tf
+++ b/modules/ecs-background/main.tf
@@ -45,13 +45,6 @@ locals {
         name  = join("_", ["SQS_QUEUE", upper(queue_short_name)])
         value = queue_name
   } if queue_short_name != local.default_queue_name]) : []
-
-  dynamodb_cache_env_vars = var.dynamodb_table_name != "" ? [
-    {
-      name  = "DYNAMODB_CACHE_TABLE"
-      value = var.dynamodb_table_name
-    },
-  ] : []
 }
 
 
@@ -100,8 +93,7 @@ module "container" {
       },
     ],
     var.container_environment,
-    local.queue_env_vars,
-    local.dynamodb_cache_env_vars
+    local.queue_env_vars
   )
   secrets       = var.container_ssm_secrets
   port_mappings = var.container_port_mappings
@@ -275,7 +267,7 @@ module "ecs_codepipeline" {
   codestar_connection_arn = var.codestar_connection_arn
   github_oauth_token      = var.codepipeline_github_oauth_token
   github_webhook_events   = var.codepipeline_github_webhook_events
-  webhook_enabled = var.codepipeline_webhook_enabled
+  webhook_enabled         = var.codepipeline_webhook_enabled
 
   codebuild_vpc_config = var.codebuild_vpc_config
 

--- a/modules/ecs-web/main.tf
+++ b/modules/ecs-web/main.tf
@@ -84,24 +84,6 @@ locals {
         name  = join("_", ["SQS_QUEUE", upper(queue_short_name)])
         value = queue_name
   } if queue_short_name != local.default_queue_name]) : []
-
-  redis_cache_env_vars = var.provision_redis_cache ? [
-    {
-      name  = "REDIS_HOST"
-      value = format("tls://%s", module.redis.endpoint)
-    }
-  ] : []
-
-  dynamodb_cache_env_vars = var.provision_dynamodb_cache ? [
-    {
-      name  = "DYNAMODB_CACHE_TABLE"
-      value = module.dynamodb.table_name
-    },
-    # {
-    #   name  = "DYNAMODB_ENDPOINT"
-    #   value = module.dynamodb.table_name
-    # },
-  ] : []
 }
 
 // ECR Registry/Repo
@@ -207,8 +189,6 @@ module "container_php-fpm" {
     },
     ],
     var.container_environment_php,
-    local.dynamodb_cache_env_vars,
-    local.redis_cache_env_vars,
     local.queue_env_vars
   )
   secrets = var.container_ssm_secrets_php
@@ -563,9 +543,9 @@ resource "aws_codestarconnections_connection" "default" {
 }
 
 module "ecs_codepipeline" {
-  source  = "cloudposse/ecs-codepipeline/aws"
-  version = "0.33.0"
-  # source = "git::https://github.com/deploymode/terraform-aws-ecs-codepipeline-1?ref=update-upstream-modules"
+  # source  = "cloudposse/ecs-codepipeline/aws"
+  # version = "0.33.0"
+  source = "git::https://github.com/deploymode/terraform-aws-ecs-codepipeline-1?ref=update-upstream-modules"
 
   enabled                         = var.codepipeline_enabled
   region                          = var.aws_region
@@ -804,7 +784,7 @@ module "redis" {
 # This can be assigned to other resources, such as the ECS task
 module "redis_allowed_sg" {
   source  = "cloudposse/security-group/aws"
-  version = "2.0.0-rc1"
+  version = "2.2.0"
 
   enabled = module.this.enabled && var.provision_redis_cache
 

--- a/modules/ecs-web/variables.tf
+++ b/modules/ecs-web/variables.tf
@@ -588,7 +588,7 @@ variable "redis_password" {
 
 }
 
-// Redis
+// DynamoDB 
 
 variable "provision_dynamodb_cache" {
   type        = bool


### PR DESCRIPTION
- Resources may be provisioned with this version but the corresponding env vars are not added
- This allows reconfiguring the app to use a new cache in a new task definition, which can be deployed before destroying the (old) cache resources created by this module
- affected env vars:
  - REDIS_HOST
  - DYNAMODB_CACHE_TABLE
- add separate cache modules for redis, memcached and dynamodb