### PR TITLE
Manage read replica allocated_storage

### DIFF
--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -160,6 +160,7 @@ module "rds_replica" {
   database_port     = var.database_port
 
   storage_type      = var.storage_type
+  allocated_storage = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
   storage_encrypted = var.storage_encrypted
 


### PR DESCRIPTION
The rds_replica block forwarded max_allocated_storage but not allocated_storage, so Terraform never managed the replica's storage size. A read replica only inherits the source's storage at creation; a later manual allocated_storage increase on the source is not mirrored to the replica, and with autoscaling disabled (max_allocated_storage = 0) AWS does not grow it either, leaving the replica smaller than its source.

Forward var.allocated_storage to the replica so it stays in step with the primary.