### PR TITLE
fix(eb-app): apply additional_settings_worker to Worker tier

### DIFF
--- a/modules/eb-app/main.tf
+++ b/modules/eb-app/main.tf
@@ -24,7 +24,7 @@ locals {
   } : {}
 
   # For ElasticBeanstalk worker tier
-  additional_settings_worker = local.queue_enabled ? [
+  additional_settings_worker = concat(local.queue_enabled ? [
     {
       namespace = "aws:elasticbeanstalk:sqsd"
       name      = "WorkerQueueURL"
@@ -36,7 +36,7 @@ locals {
       value     = var.queue_http_url
 
     }
-  ] : []
+  ] : [], var.additional_settings_worker)
 
   web_environments = toset([for name, environment in var.environment_settings : name if environment.tier == "WebServer"])
 

--- a/modules/eb-app/variables.tf
+++ b/modules/eb-app/variables.tf
@@ -352,6 +352,17 @@ variable "additional_settings" {
   default     = []
 }
 
+variable "additional_settings_worker" {
+  type = list(object({
+    namespace = string
+    name      = string
+    value     = string
+  }))
+
+  description = "Additional Elastic Beanstalk settings applied only to the Worker tier (e.g. aws:elasticbeanstalk:sqsd options)."
+  default     = []
+}
+
 variable "env_vars" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
The additional_settings_worker input was passed by callers but never declared or used, so Terraform silently dropped it. Declare the variable and concat it into the Worker tier's settings so per-worker options (e.g. aws:elasticbeanstalk:sqsd HttpConnections) actually take effect.