### PR TITLE
feat(ecs-web): expose ALB idle_timeout

### DIFF
--- a/modules/ecs-web/main.tf
+++ b/modules/ecs-web/main.tf
@@ -326,6 +326,7 @@ module "alb" {
   health_check_interval                   = var.alb_healthcheck_interval
   health_check_healthy_threshold          = var.alb_healthcheck_healthy_threshold
   health_check_unhealthy_threshold        = var.alb_healthcheck_unhealthy_threshold
+  idle_timeout                            = var.alb_idle_timeout
   certificate_arn                         = var.certificate_arn
   access_logs_enabled                     = var.alb_access_logs_enabled
   alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy

--- a/modules/ecs-web/variables.tf
+++ b/modules/ecs-web/variables.tf
@@ -83,6 +83,12 @@ variable "alb_healthcheck_unhealthy_threshold" {
   default     = 2
 }
 
+variable "alb_idle_timeout" {
+  type        = number
+  description = "The time in seconds that the connection to the ALB is allowed to be idle"
+  default     = 60
+}
+
 variable "target_group_port" {
   type        = number
   default     = 80


### PR DESCRIPTION
Pass idle_timeout through to the cloudposse/alb module so slow synchronous endpoints are not cut off at the 60s AWS default.