### PR TITLE
feat(ecs-background): step-scaling autoscaling on weighted SQS backlog

### DIFF
--- a/modules/alarm-notifications/context.tf
+++ b/modules/alarm-notifications/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/alarm-notifications/main.tf
+++ b/modules/alarm-notifications/main.tf
@@ -1,0 +1,74 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# Terraform-managed Betterstack CloudWatch integration. Requires the
+# BETTERUPTIME_API_TOKEN environment variable at plan/apply time.
+resource "betteruptime_aws_cloudwatch_integration" "this" {
+  count = module.this.enabled && var.betterstack_enabled ? 1 : 0
+
+  name            = module.this.id
+  policy_id       = var.betterstack_policy_id
+  recovery_period = var.betterstack_recovery_period
+}
+
+# Fallback for a webhook created outside Terraform: the URL carries an ingest
+# token, so it is read from SSM (seeded out-of-band) rather than passed as a
+# plain input that would sit in git.
+data "aws_ssm_parameter" "webhook_url" {
+  count = module.this.enabled && !var.betterstack_enabled && var.webhook_url_ssm_param != "" ? 1 : 0
+
+  name            = var.webhook_url_ssm_param
+  with_decryption = true
+}
+
+locals {
+  webhook_subscribed = module.this.enabled && (var.betterstack_enabled || var.webhook_url_ssm_param != "")
+  webhook_url        = var.betterstack_enabled ? try(betteruptime_aws_cloudwatch_integration.this[0].webhook_url, null) : try(data.aws_ssm_parameter.webhook_url[0].value, null)
+}
+
+resource "aws_sns_topic" "alarms" {
+  count = module.this.enabled ? 1 : 0
+
+  name = module.this.id
+  tags = module.this.tags
+}
+
+resource "aws_sns_topic_policy" "alarms" {
+  count = module.this.enabled ? 1 : 0
+
+  arn = aws_sns_topic.alarms[0].arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudWatchAlarmsPublish"
+        Effect    = "Allow"
+        Principal = { Service = "cloudwatch.amazonaws.com" }
+        Action    = "SNS:Publish"
+        Resource  = aws_sns_topic.alarms[0].arn
+        Condition = {
+          StringEquals = { "AWS:SourceAccount" = data.aws_caller_identity.current.account_id }
+          ArnLike      = { "AWS:SourceArn" = "arn:aws:cloudwatch:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alarm:*" }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "webhook" {
+  count = local.webhook_subscribed ? 1 : 0
+
+  topic_arn              = aws_sns_topic.alarms[0].arn
+  protocol               = "https"
+  endpoint               = local.webhook_url
+  endpoint_auto_confirms = true
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  for_each = module.this.enabled ? toset(var.notification_emails) : toset([])
+
+  topic_arn = aws_sns_topic.alarms[0].arn
+  protocol  = "email"
+  endpoint  = each.value
+}

--- a/modules/alarm-notifications/outputs.tf
+++ b/modules/alarm-notifications/outputs.tf
@@ -1,0 +1,4 @@
+output "sns_topic_arn" {
+  description = "ARN of the alarm notification SNS topic."
+  value       = try(aws_sns_topic.alarms[0].arn, null)
+}

--- a/modules/alarm-notifications/variables.tf
+++ b/modules/alarm-notifications/variables.tf
@@ -1,0 +1,29 @@
+variable "betterstack_enabled" {
+  type        = bool
+  description = "Create a Betterstack AWS CloudWatch integration via the better-uptime provider and subscribe its webhook to the topic. Requires BETTERUPTIME_API_TOKEN in the environment."
+  default     = false
+}
+
+variable "betterstack_policy_id" {
+  type        = string
+  description = "Betterstack escalation policy id for the integration"
+  default     = null
+}
+
+variable "betterstack_recovery_period" {
+  type        = number
+  description = "Seconds an alert must stay OK before Betterstack auto-resolves the incident"
+  default     = 0
+}
+
+variable "webhook_url_ssm_param" {
+  type        = string
+  description = "SSM parameter name holding an externally created webhook URL to subscribe to the topic. Ignored when betterstack_enabled; empty to skip."
+  default     = ""
+}
+
+variable "notification_emails" {
+  type        = list(string)
+  description = "Email addresses to subscribe to the topic"
+  default     = []
+}

--- a/modules/alarm-notifications/versions.tf
+++ b/modules/alarm-notifications/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = ">= 4.40.0"
+    betteruptime = {
+      source  = "BetterStackHQ/better-uptime"
+      version = ">= 0.21.0"
+    }
+  }
+}

--- a/modules/db/alarms.tf
+++ b/modules/db/alarms.tf
@@ -1,0 +1,116 @@
+locals {
+  alarms_enabled         = module.this.enabled && var.alarms_enabled
+  replica_alarms_enabled = local.alarms_enabled && var.create_replica
+  # CPUCreditBalance only exists on burstable instance classes
+  burstable = length(regexall("^db\\.t", var.instance_class)) > 0
+
+  cpu_credit_alarm_instances = local.burstable ? merge(
+    { writer = module.rds_instance.instance_id },
+    local.replica_alarms_enabled ? { replica = module.rds_replica.instance_id } : {}
+  ) : {}
+}
+
+resource "aws_cloudwatch_metric_alarm" "writer_cpu" {
+  count = local.alarms_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-writer-cpu-high"
+  alarm_description   = "RDS writer CPU utilisation is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  dimensions          = { DBInstanceIdentifier = module.rds_instance.instance_id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.alarm_writer_cpu_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "replica_cpu" {
+  count = local.replica_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-replica-cpu-high"
+  alarm_description   = "RDS replica CPU utilisation is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  dimensions          = { DBInstanceIdentifier = module.rds_replica.instance_id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.alarm_replica_cpu_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "replica_read_latency" {
+  count = local.replica_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-replica-read-latency-high"
+  alarm_description   = "RDS replica read latency is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "ReadLatency"
+  dimensions          = { DBInstanceIdentifier = module.rds_replica.instance_id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.alarm_replica_read_latency_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "replica_connections" {
+  count = local.replica_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-replica-connections-high"
+  alarm_description   = "RDS replica connection count is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  dimensions          = { DBInstanceIdentifier = module.rds_replica.instance_id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.alarm_database_connections_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance" {
+  for_each = local.alarms_enabled ? local.cpu_credit_alarm_instances : {}
+
+  alarm_name          = "${module.this.id}-${each.key}-cpu-credits-low"
+  alarm_description   = "RDS ${each.key} CPU credit balance is running low"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUCreditBalance"
+  dimensions          = { DBInstanceIdentifier = each.value }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "LessThanThreshold"
+  threshold           = var.alarm_cpu_credit_balance_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -398,3 +398,46 @@ variable "promote_replica" {
   description = "Promote the read replica to a standalone DB"
   default     = false
 }
+// Alarms
+
+variable "alarms_enabled" {
+  type        = bool
+  description = "Create CloudWatch alarms for the DB instances"
+  default     = false
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "Actions (e.g. SNS topic ARNs) to notify on alarm and OK transitions"
+  default     = []
+}
+
+variable "alarm_replica_cpu_threshold" {
+  type        = number
+  description = "Replica CPUUtilization percentage above which to alarm"
+  default     = 80
+}
+
+variable "alarm_replica_read_latency_threshold" {
+  type        = number
+  description = "Replica ReadLatency (seconds) above which to alarm"
+  default     = 0.02
+}
+
+variable "alarm_database_connections_threshold" {
+  type        = number
+  description = "Replica DatabaseConnections count above which to alarm"
+  default     = 80
+}
+
+variable "alarm_cpu_credit_balance_threshold" {
+  type        = number
+  description = "CPUCreditBalance below which to alarm on burstable instances"
+  default     = 100
+}
+
+variable "alarm_writer_cpu_threshold" {
+  type        = number
+  description = "Writer CPUUtilization percentage above which to alarm"
+  default     = 80
+}

--- a/modules/ecs-background/main.tf
+++ b/modules/ecs-background/main.tf
@@ -32,7 +32,9 @@ locals {
     codebuild = "/aws/codebuild/${module.this.id}-build"
   } : {}
 
-  queue_env_vars = length(var.queue_names) > 0 ? concat([
+  queue_in_use = length(var.queue_names) > 0
+
+  queue_env_vars = local.queue_in_use ? concat([
     {
       name  = "QUEUE_CONNECTION"
       value = "sqs"
@@ -56,8 +58,6 @@ locals {
         value = queue_name
   } if queue_short_name != local.default_queue_name]) : []
 }
-
-
 
 // ECR Registry/Repo
 module "ecr" {
@@ -242,6 +242,232 @@ module "ecs_task_run_policy" {
   context = module.this.context
 }
 
+// Auto-scaling based on SQS queue metrics
+//
+// Queues are served by fixed per-task process pools, so a single fleet-wide
+// capacity number would hide a drowning pool behind an idle one. The signal
+// is therefore per-queue: weighted backlog divided by the slots that can
+// actually drain that queue (running tasks * queue_processes[queue]), and
+// the alarm scales on the WORST queue (MAX). Every queue in queue_names
+// participates at queue_weight_default; queue_weights overrides exceptions.
+// The scale-down signal additionally counts in-flight (not-visible) messages
+// on the queues named in scale_in_inflight_queues, so the fleet does not
+// shrink while long-running jobs are still executing. That narrows, but does
+// not close, the race between a scale-in decision and task termination —
+// ECS task scale-in protection (set from inside the task) is the real fix.
+// Step-adjustment intervals are relative to the alarm thresholds, per the
+// CloudWatch step-scaling contract.
+//
+// CloudWatch allows at most 10 metrics per alarm: queues + inflight queues
+// + the task-count metric must stay within that.
+
+locals {
+  autoscaling_enabled = module.this.enabled && var.autoscaling_enabled && local.queue_in_use
+
+  autoscaling_queue_weights = { for k in keys(var.queue_names) : k => lookup(var.queue_weights, k, var.queue_weight_default) }
+  autoscaling_queue_procs   = { for k in keys(var.queue_names) : k => lookup(var.queue_processes, k, var.process_capacity_per_worker) }
+
+  # Metric-math ids must match [a-z][a-zA-Z0-9_]*; queue names may not, so
+  # derive ids from the sorted key position instead.
+  autoscaling_queue_index = { for i, k in sort(keys(var.queue_names)) : k => i }
+
+  autoscaling_inflight_index = { for k, i in local.autoscaling_queue_index : k => i if contains(var.scale_in_inflight_queues, k) }
+
+  # Per-queue load expressions: (backlog * weight) / (tasks * pool slots).
+  # The scale-down variant adds the in-flight metric where configured.
+  autoscaling_load_exprs = {
+    for k, i in local.autoscaling_queue_index :
+    i => "(v${i} * ${local.autoscaling_queue_weights[k]}) / (tasks * ${local.autoscaling_queue_procs[k]})"
+  }
+  autoscaling_load_exprs_with_inflight = {
+    for k, i in local.autoscaling_queue_index :
+    i => "((v${i}${contains(var.scale_in_inflight_queues, k) ? " + n${i}" : ""}) * ${local.autoscaling_queue_weights[k]}) / (tasks * ${local.autoscaling_queue_procs[k]})"
+  }
+
+  autoscaling_max_expr = "MAX([${join(", ", [for i in values(local.autoscaling_queue_index) : "l${i}"])}])"
+}
+
+module "ecs_cloudwatch_autoscaling" {
+  source  = "cloudposse/ecs-cloudwatch-autoscaling/aws"
+  version = "1.0.0"
+
+  enabled = local.autoscaling_enabled
+
+  service_name                = module.ecs_task.service_name
+  cluster_name                = var.ecs_cluster_name
+  min_capacity                = var.autoscaling_min_capacity
+  max_capacity                = var.autoscaling_max_capacity
+  scale_up_step_adjustments   = var.autoscaling_scale_up_step_adjustments
+  scale_up_cooldown           = var.autoscaling_scale_up_cooldown
+  scale_down_step_adjustments = var.autoscaling_scale_down_step_adjustments
+  scale_down_cooldown         = var.autoscaling_scale_down_cooldown
+
+  context = module.this.context
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
+  count = local.autoscaling_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-scale-up"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.autoscaling_scale_up_threshold
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  alarm_description   = "Scale up ${module.ecs_task.service_name} when any queue's backlog per process slot exceeds threshold"
+  treat_missing_data  = "notBreaching"
+
+  dynamic "metric_query" {
+    for_each = local.autoscaling_queue_index
+    content {
+      id = "v${metric_query.value}"
+      metric {
+        namespace   = "AWS/SQS"
+        metric_name = "ApproximateNumberOfMessagesVisible"
+        dimensions  = { QueueName = var.queue_names[metric_query.key] }
+        period      = 60
+        stat        = "Average"
+      }
+    }
+  }
+
+  metric_query {
+    id = "tasks"
+    metric {
+      namespace   = "ECS/ContainerInsights"
+      metric_name = "RunningTaskCount"
+      dimensions = {
+        ClusterName = var.ecs_cluster_name
+        ServiceName = module.ecs_task.service_name
+      }
+      period = 60
+      stat   = "Average"
+    }
+  }
+
+  dynamic "metric_query" {
+    for_each = local.autoscaling_load_exprs
+    content {
+      id         = "l${metric_query.key}"
+      expression = metric_query.value
+      label      = "Load per slot q${metric_query.key}"
+    }
+  }
+
+  metric_query {
+    id          = "workload_per_slot"
+    expression  = local.autoscaling_max_expr
+    label       = "Worst Queue Load Per Slot"
+    return_data = true
+  }
+
+  alarm_actions = [module.ecs_cloudwatch_autoscaling.scale_up_policy_arn]
+
+  tags = module.this.tags
+
+  lifecycle {
+    precondition {
+      condition     = alltrue([for k in keys(var.queue_weights) : contains(keys(var.queue_names), k)])
+      error_message = "Every queue_weights key must exist in queue_names."
+    }
+    precondition {
+      condition     = alltrue([for k in keys(var.queue_processes) : contains(keys(var.queue_names), k)])
+      error_message = "Every queue_processes key must exist in queue_names."
+    }
+    precondition {
+      condition     = alltrue([for k in var.scale_in_inflight_queues : contains(keys(var.queue_names), k)])
+      error_message = "Every scale_in_inflight_queues entry must exist in queue_names."
+    }
+    precondition {
+      condition     = length(var.queue_names) + 1 <= 10
+      error_message = "CloudWatch alarms allow at most 10 metrics: too many queues."
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
+  count = local.autoscaling_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-scale-down"
+  comparison_operator = "LessThanThreshold"
+  threshold           = var.autoscaling_scale_down_threshold
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  # notBreaching: an idle-but-running service reports workload 0 and still
+  # scales down; missing data (metric gaps, zero tasks) must not force scale-in.
+  alarm_description  = "Scale down ${module.ecs_task.service_name} when every queue's backlog (including in-flight work on slow queues) is below threshold"
+  treat_missing_data = "notBreaching"
+
+  dynamic "metric_query" {
+    for_each = local.autoscaling_queue_index
+    content {
+      id = "v${metric_query.value}"
+      metric {
+        namespace   = "AWS/SQS"
+        metric_name = "ApproximateNumberOfMessagesVisible"
+        dimensions  = { QueueName = var.queue_names[metric_query.key] }
+        period      = 60
+        stat        = "Average"
+      }
+    }
+  }
+
+  # In-flight messages on the slow queues: while a long job is executing its
+  # message is not-visible, which holds this signal up and defers scale-in.
+  dynamic "metric_query" {
+    for_each = local.autoscaling_inflight_index
+    content {
+      id = "n${metric_query.value}"
+      metric {
+        namespace   = "AWS/SQS"
+        metric_name = "ApproximateNumberOfMessagesNotVisible"
+        dimensions  = { QueueName = var.queue_names[metric_query.key] }
+        period      = 60
+        stat        = "Average"
+      }
+    }
+  }
+
+  metric_query {
+    id = "tasks"
+    metric {
+      namespace   = "ECS/ContainerInsights"
+      metric_name = "RunningTaskCount"
+      dimensions = {
+        ClusterName = var.ecs_cluster_name
+        ServiceName = module.ecs_task.service_name
+      }
+      period = 60
+      stat   = "Average"
+    }
+  }
+
+  dynamic "metric_query" {
+    for_each = local.autoscaling_load_exprs_with_inflight
+    content {
+      id         = "l${metric_query.key}"
+      expression = metric_query.value
+      label      = "Load per slot q${metric_query.key}"
+    }
+  }
+
+  metric_query {
+    id          = "workload_per_slot"
+    expression  = local.autoscaling_max_expr
+    label       = "Worst Queue Load Per Slot"
+    return_data = true
+  }
+
+  alarm_actions = [module.ecs_cloudwatch_autoscaling.scale_down_policy_arn]
+
+  tags = module.this.tags
+
+  lifecycle {
+    precondition {
+      condition     = length(var.queue_names) + length(var.scale_in_inflight_queues) + 1 <= 10
+      error_message = "CloudWatch alarms allow at most 10 metrics: reduce queues or scale_in_inflight_queues."
+    }
+  }
+}
 
 //////////
 // ECS Task Role Policies
@@ -377,7 +603,7 @@ module "ecs_codepipeline" {
   environment_variables = concat(
     var.codepipeline_environment_variables,
     var.codepipeline_add_queue_env_vars ?
-    [for var in local.queue_env_vars : merge(var, { type = "PLAINTEXT" })] : [],
+    [for queue_var in local.queue_env_vars : merge(queue_var, { type = "PLAINTEXT" })] : [],
     [
       {
         name  = "NAMESPACE"

--- a/modules/ecs-background/variables.tf
+++ b/modules/ecs-background/variables.tf
@@ -639,3 +639,103 @@ variable "scheduled_task_count" {
   type        = number
   default     = 1
 }
+
+
+variable "process_capacity_per_worker" {
+  type        = number
+  description = "Number of queue processes per worker"
+  default     = 5
+}
+
+variable "queue_weights" {
+  type        = map(number)
+  description = "Per-queue weight overrides for scaling decisions. Queues not listed here use queue_weight_default; keys must exist in queue_names. Set a queue to 0 to exclude it from the scaling signal."
+  default     = {}
+}
+
+variable "queue_weight_default" {
+  type        = number
+  description = "Weight applied to any queue in queue_names without an entry in queue_weights"
+  default     = 1
+}
+
+variable "queue_processes" {
+  type        = map(number)
+  description = "Worker processes per task that serve each queue (keys must exist in queue_names). Queues not listed fall back to process_capacity_per_worker."
+  default     = {}
+}
+
+variable "scale_in_inflight_queues" {
+  type        = list(string)
+  description = "Queues whose in-flight (not-visible) messages are added to the scale-down signal, deferring scale-in while their jobs run. Use for slow queues; entries must exist in queue_names."
+  default     = []
+}
+
+variable "autoscaling_enabled" {
+  type        = bool
+  description = "A boolean to enable/disable Autoscaling policy for ECS Service"
+  default     = false
+}
+
+variable "autoscaling_min_capacity" {
+  type        = number
+  description = "Minimum number of ECS tasks for Autoscaling"
+  default     = 1
+}
+
+variable "autoscaling_max_capacity" {
+  type        = number
+  description = "Maximum number of ECS tasks for Autoscaling"
+  default     = 5
+}
+
+variable "autoscaling_scale_up_cooldown" {
+  type        = number
+  description = "Period (in seconds) to wait between scale up events"
+  default     = 60
+}
+
+variable "autoscaling_scale_down_cooldown" {
+  type        = number
+  description = "Period (in seconds) to wait between scale down events"
+  default     = 300
+}
+
+# Scaling thresholds. Step-adjustment intervals are offsets from the
+# corresponding threshold, per the CloudWatch step-scaling contract.
+variable "autoscaling_scale_up_threshold" {
+  type        = number
+  description = "Scale up when workload per process slot exceeds this value. 1.0 means the visible weighted backlog equals total process capacity."
+  default     = 1.0
+}
+
+variable "autoscaling_scale_up_step_adjustments" {
+  description = "Step adjustments for scaling up, with metric intervals relative to autoscaling_scale_up_threshold"
+  type = list(object({
+    metric_interval_lower_bound = optional(number)
+    metric_interval_upper_bound = optional(number)
+    scaling_adjustment          = number
+  }))
+  default = [
+    { metric_interval_lower_bound = 0, metric_interval_upper_bound = 2, scaling_adjustment = 1 },
+    { metric_interval_lower_bound = 2, metric_interval_upper_bound = null, scaling_adjustment = 2 },
+  ]
+}
+
+variable "autoscaling_scale_down_threshold" {
+  type        = number
+  description = "Scale down when workload per process slot drops below this value"
+  default     = 0.3
+}
+
+variable "autoscaling_scale_down_step_adjustments" {
+  description = "Step adjustments for scaling down, with metric intervals relative to autoscaling_scale_down_threshold"
+  type = list(object({
+    metric_interval_lower_bound = optional(number)
+    metric_interval_upper_bound = optional(number)
+    scaling_adjustment          = number
+  }))
+  default = [
+    { metric_interval_lower_bound = null, metric_interval_upper_bound = 0, scaling_adjustment = -1 },
+  ]
+}

--- a/modules/queue/outputs.tf
+++ b/modules/queue/outputs.tf
@@ -21,3 +21,8 @@ output "queue_region" {
   description = "SQS region"
   value       = data.aws_region.current.name
 }
+
+output "queue_visibility_timeout" {
+  description = "Visibility timeout (seconds) per queue"
+  value       = module.this.enabled ? { for queue, queue_info in var.queues : queue => queue_info.visibility_timeout_seconds if queue_info.enabled } : {}
+}


### PR DESCRIPTION
Scales the service via cloudposse/ecs-cloudwatch-autoscaling step policies, driven by metric-math alarms on weighted visible messages per process slot. Fixes from the original spike: cloudposse step-adjustment shapes, policy ARNs from module outputs, real queue names in alarm dimensions, sanitised metric ids, namespaced alarm names, alarms gated on autoscaling_enabled, RunningTaskCount read from ECS/ContainerInsights.