### PR TITLE
fix!: keep alarm-notifications AWS-only

### DIFF
--- a/modules/alarm-notifications/main.tf
+++ b/modules/alarm-notifications/main.tf
@@ -2,29 +2,14 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-# Terraform-managed Betterstack CloudWatch integration. Requires the
-# BETTERUPTIME_API_TOKEN environment variable at plan/apply time.
-resource "betteruptime_aws_cloudwatch_integration" "this" {
-  count = module.this.enabled && var.betterstack_enabled ? 1 : 0
-
-  name            = module.this.id
-  policy_id       = var.betterstack_policy_id
-  recovery_period = var.betterstack_recovery_period
-}
-
-# Fallback for a webhook created outside Terraform: the URL carries an ingest
-# token, so it is read from SSM (seeded out-of-band) rather than passed as a
-# plain input that would sit in git.
+# Optional webhook created outside this module (e.g. an alerting SaaS ingest
+# URL): the URL carries a token, so it is read from SSM (seeded out-of-band)
+# rather than passed as a plain input that would sit in git.
 data "aws_ssm_parameter" "webhook_url" {
-  count = module.this.enabled && !var.betterstack_enabled && var.webhook_url_ssm_param != "" ? 1 : 0
+  count = module.this.enabled && var.webhook_url_ssm_param != "" ? 1 : 0
 
   name            = var.webhook_url_ssm_param
   with_decryption = true
-}
-
-locals {
-  webhook_subscribed = module.this.enabled && (var.betterstack_enabled || var.webhook_url_ssm_param != "")
-  webhook_url        = var.betterstack_enabled ? try(betteruptime_aws_cloudwatch_integration.this[0].webhook_url, null) : try(data.aws_ssm_parameter.webhook_url[0].value, null)
 }
 
 resource "aws_sns_topic" "alarms" {
@@ -57,11 +42,11 @@ resource "aws_sns_topic_policy" "alarms" {
 }
 
 resource "aws_sns_topic_subscription" "webhook" {
-  count = local.webhook_subscribed ? 1 : 0
+  count = module.this.enabled && var.webhook_url_ssm_param != "" ? 1 : 0
 
   topic_arn              = aws_sns_topic.alarms[0].arn
   protocol               = "https"
-  endpoint               = local.webhook_url
+  endpoint               = data.aws_ssm_parameter.webhook_url[0].value
   endpoint_auto_confirms = true
 }
 

--- a/modules/alarm-notifications/variables.tf
+++ b/modules/alarm-notifications/variables.tf
@@ -1,24 +1,6 @@
-variable "betterstack_enabled" {
-  type        = bool
-  description = "Create a Betterstack AWS CloudWatch integration via the better-uptime provider and subscribe its webhook to the topic. Requires BETTERUPTIME_API_TOKEN in the environment."
-  default     = false
-}
-
-variable "betterstack_policy_id" {
-  type        = string
-  description = "Betterstack escalation policy id for the integration"
-  default     = null
-}
-
-variable "betterstack_recovery_period" {
-  type        = number
-  description = "Seconds an alert must stay OK before Betterstack auto-resolves the incident"
-  default     = 0
-}
-
 variable "webhook_url_ssm_param" {
   type        = string
-  description = "SSM parameter name holding an externally created webhook URL to subscribe to the topic. Ignored when betterstack_enabled; empty to skip."
+  description = "SSM parameter name holding an externally created webhook URL to subscribe to the topic. Empty to skip."
   default     = ""
 }
 

--- a/modules/alarm-notifications/versions.tf
+++ b/modules/alarm-notifications/versions.tf
@@ -3,9 +3,5 @@ terraform {
 
   required_providers {
     aws = ">= 4.40.0"
-    betteruptime = {
-      source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.0"
-    }
   }
 }


### PR DESCRIPTION
Remove the Betterstack integration and better-uptime provider; this repo's modules are AWS-only. Consumers attach SaaS-specific webhooks by subscribing to the exported sns_topic_arn from their own modules. Breaking: drops betterstack_enabled, betterstack_policy_id, betterstack_recovery_period.