### PR TITLE
feat(db): primary DatabaseConnections alarm; primary/replica naming

### DIFF
--- a/modules/db/alarms.tf
+++ b/modules/db/alarms.tf
@@ -5,16 +5,18 @@ locals {
   burstable = length(regexall("^db\\.t", var.instance_class)) > 0
 
   cpu_credit_alarm_instances = local.burstable ? merge(
-    { writer = module.rds_instance.instance_id },
+    { primary = module.rds_instance.instance_id },
     local.replica_alarms_enabled ? { replica = module.rds_replica.instance_id } : {}
   ) : {}
 }
 
-resource "aws_cloudwatch_metric_alarm" "writer_cpu" {
+// Primary instance
+
+resource "aws_cloudwatch_metric_alarm" "primary_cpu" {
   count = local.alarms_enabled ? 1 : 0
 
-  alarm_name          = "${module.this.id}-writer-cpu-high"
-  alarm_description   = "RDS writer CPU utilisation is high"
+  alarm_name          = "${module.this.id}-primary-cpu-high"
+  alarm_description   = "RDS primary CPU utilisation is high"
   namespace           = "AWS/RDS"
   metric_name         = "CPUUtilization"
   dimensions          = { DBInstanceIdentifier = module.rds_instance.instance_id }
@@ -23,13 +25,36 @@ resource "aws_cloudwatch_metric_alarm" "writer_cpu" {
   evaluation_periods  = 3
   datapoints_to_alarm = 3
   comparison_operator = "GreaterThanThreshold"
-  threshold           = var.alarm_writer_cpu_threshold
+  threshold           = var.alarm_primary_cpu_threshold
   treat_missing_data  = "notBreaching"
   alarm_actions       = var.alarm_actions
   ok_actions          = var.alarm_actions
 
   tags = module.this.tags
 }
+
+resource "aws_cloudwatch_metric_alarm" "primary_connections" {
+  count = local.alarms_enabled ? 1 : 0
+
+  alarm_name          = "${module.this.id}-primary-connections-high"
+  alarm_description   = "RDS primary connection count is high"
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  dimensions          = { DBInstanceIdentifier = module.rds_instance.instance_id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.alarm_database_connections_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions
+  ok_actions          = var.alarm_actions
+
+  tags = module.this.tags
+}
+
+// Replica instance
 
 resource "aws_cloudwatch_metric_alarm" "replica_cpu" {
   count = local.replica_alarms_enabled ? 1 : 0
@@ -93,6 +118,8 @@ resource "aws_cloudwatch_metric_alarm" "replica_connections" {
 
   tags = module.this.tags
 }
+
+// Burstable instances (primary and replica)
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance" {
   for_each = local.alarms_enabled ? local.cpu_credit_alarm_instances : {}

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -412,6 +412,16 @@ variable "alarm_actions" {
   default     = []
 }
 
+// Alarm thresholds: primary
+
+variable "alarm_primary_cpu_threshold" {
+  type        = number
+  description = "Primary CPUUtilization percentage above which to alarm"
+  default     = 80
+}
+
+// Alarm thresholds: replica
+
 variable "alarm_replica_cpu_threshold" {
   type        = number
   description = "Replica CPUUtilization percentage above which to alarm"
@@ -424,9 +434,11 @@ variable "alarm_replica_read_latency_threshold" {
   default     = 0.02
 }
 
+// Alarm thresholds: primary and replica
+
 variable "alarm_database_connections_threshold" {
   type        = number
-  description = "Replica DatabaseConnections count above which to alarm"
+  description = "DatabaseConnections count above which to alarm"
   default     = 80
 }
 
@@ -434,10 +446,4 @@ variable "alarm_cpu_credit_balance_threshold" {
   type        = number
   description = "CPUCreditBalance below which to alarm on burstable instances"
   default     = 100
-}
-
-variable "alarm_writer_cpu_threshold" {
-  type        = number
-  description = "Writer CPUUtilization percentage above which to alarm"
-  default     = 80
 }


### PR DESCRIPTION
Adds a DatabaseConnections alarm on the primary (with no replica, all connections land there), renames the writer-named alarm and threshold to primary to match the module's primary/replica terminology, and groups the alarm variables by instance. Renaming recreates any already-applied writer-named alarms.