### PR TITLE
fix(ecs-background): autoscaling owns the service desired count

### DIFF
--- a/modules/ecs-background/main.tf
+++ b/modules/ecs-background/main.tf
@@ -168,6 +168,8 @@ module "ecs_task" {
   enable_icmp_rule               = false
   tags                           = var.tags
   ignore_changes_task_definition = var.ecs_ignore_changes_task_definition
+  # When autoscaling owns the desired count, applies must not reset it.
+  ignore_changes_desired_count = local.autoscaling_enabled
 
   network_mode   = var.ecs_network_mode
   container_port = var.container_port


### PR DESCRIPTION
When autoscaling is enabled the ECS service ignores desired-count changes, so terraform applies no longer reset the count the autoscaler set. Note: flipping this switches the cloudposse service resource variant, which replaces the ECS service on the next apply.