### PR TITLE
fix(ecs-web, ecs-background): reduce task def flapping on plan/apply

### DIFF
--- a/modules/ecs-background/main.tf
+++ b/modules/ecs-background/main.tf
@@ -574,9 +574,7 @@ resource "aws_service_discovery_service" "service_discovery" {
 
   }
 
-  health_check_custom_config {
-    failure_threshold = 1
-  }
+  health_check_custom_config {}
 }
 
 // CodePipeline using ECS Deploy

--- a/modules/ecs-background/main.tf
+++ b/modules/ecs-background/main.tf
@@ -83,12 +83,25 @@ module "container_label" {
   context = module.this.context
 }
 
+# The latest ACTIVE task definition, used to carry the CI-deployed image tag
+# into task definitions rendered by Terraform so applies don't revert images.
+data "aws_ecs_task_definition" "deployed" {
+  count           = var.use_deployed_image && var.container_image == null ? 1 : 0
+  task_definition = module.this.id
+}
+
+data "aws_ecs_container_definition" "deployed" {
+  count           = var.use_deployed_image && var.container_image == null ? 1 : 0
+  task_definition = "${data.aws_ecs_task_definition.deployed[0].family}:${data.aws_ecs_task_definition.deployed[0].revision}"
+  container_name  = module.container_label.id
+}
+
 module "container" {
   source  = "cloudposse/ecs-container-definition/aws"
   version = "0.61.2"
 
   container_name               = module.container_label.id
-  container_image              = var.container_image == null ? join(":", [module.ecr.repository_url, "latest"]) : var.container_image
+  container_image              = var.container_image != null ? var.container_image : (var.use_deployed_image ? data.aws_ecs_container_definition.deployed[0].image : join(":", [module.ecr.repository_url, "latest"]))
   container_memory             = var.container_memory
   container_memory_reservation = var.container_memory_reservation
   container_cpu                = var.container_cpu
@@ -102,7 +115,9 @@ module "container" {
 
   readonly_root_filesystem = false
 
-  environment = concat(
+  # Entries with a null value are dropped rather than rendered as value: null,
+  # which ECS would reject / record literally.
+  environment = [for e in concat(
     [
       {
         name  = "STAGE"
@@ -113,9 +128,9 @@ module "container" {
         value = module.this.environment
       },
     ],
-    var.container_environment,
+    var.container_environment == null ? [] : var.container_environment,
     local.queue_env_vars
-  )
+  ) : e if e.value != null]
   secrets       = var.container_ssm_secrets
   port_mappings = var.container_port_mappings
   command       = var.container_command

--- a/modules/ecs-background/variables.tf
+++ b/modules/ecs-background/variables.tf
@@ -158,6 +158,12 @@ variable "ecs_task_def_track_latest" {
   default     = false
 }
 
+variable "use_deployed_image" {
+  type        = bool
+  description = "Render the container image from the latest ACTIVE task definition instead of ':latest', so Terraform applies don't revert images deployed by CI/CD. Ignored when container_image is set. Requires the task definition family to already exist; leave false for the first deployment of a new environment."
+  default     = false
+}
+
 
 
 // ECS Task Variables

--- a/modules/ecs-web/main.tf
+++ b/modules/ecs-web/main.tf
@@ -126,11 +126,30 @@ module "nginx_container_label" {
   context    = module.container_label.context
 }
 
+# The latest ACTIVE task definition, used to carry the CI-deployed image tags
+# into task definitions rendered by Terraform so applies don't revert images.
+data "aws_ecs_task_definition" "deployed" {
+  count           = var.use_deployed_image ? 1 : 0
+  task_definition = module.this.id
+}
+
+data "aws_ecs_container_definition" "deployed_nginx" {
+  count           = var.use_deployed_image ? 1 : 0
+  task_definition = "${data.aws_ecs_task_definition.deployed[0].family}:${data.aws_ecs_task_definition.deployed[0].revision}"
+  container_name  = module.nginx_container_label.id
+}
+
+data "aws_ecs_container_definition" "deployed_php-fpm" {
+  count           = var.use_deployed_image ? 1 : 0
+  task_definition = "${data.aws_ecs_task_definition.deployed[0].family}:${data.aws_ecs_task_definition.deployed[0].revision}"
+  container_name  = module.php-fpm_container_label.id
+}
+
 module "container_nginx" {
   source                       = "cloudposse/ecs-container-definition/aws"
   version                      = "0.61.2"
   container_name               = module.nginx_container_label.id #join("-", [module.container_label.id, "nginx"])
-  container_image              = join(":", [module.ecr.repository_url_map[local.image_names_map.nginx], "latest"])
+  container_image              = var.use_deployed_image ? data.aws_ecs_container_definition.deployed_nginx[0].image : join(":", [module.ecr.repository_url_map[local.image_names_map.nginx], "latest"])
   container_memory             = var.container_memory_nginx
   container_memory_reservation = var.container_memory_reservation_nginx
   container_cpu                = var.container_cpu_nginx
@@ -143,7 +162,9 @@ module "container_nginx" {
 
   readonly_root_filesystem = false
 
-  environment = var.container_environment_nginx
+  # Entries with a null value are dropped rather than rendered as value: null,
+  # which ECS would reject / record literally.
+  environment = [for e in var.container_environment_nginx : e if e.value != null]
   secrets     = var.container_ssm_secrets_nginx
 
   port_mappings = [
@@ -179,7 +200,7 @@ module "container_php-fpm" {
   source                       = "cloudposse/ecs-container-definition/aws"
   version                      = "0.61.2"
   container_name               = module.php-fpm_container_label.id # join("-", [module.container_label.id, "php-fpm"])
-  container_image              = join(":", [module.ecr.repository_url_map[local.image_names_map.php], "latest"])
+  container_image              = var.use_deployed_image ? data.aws_ecs_container_definition.deployed_php-fpm[0].image : join(":", [module.ecr.repository_url_map[local.image_names_map.php], "latest"])
   container_memory             = var.container_memory_php
   container_memory_reservation = var.container_memory_reservation_php
   container_cpu                = var.container_cpu_php
@@ -198,7 +219,9 @@ module "container_php-fpm" {
 
   readonly_root_filesystem = false
 
-  environment = concat([
+  # Entries with a null value are dropped rather than rendered as value: null,
+  # which ECS would reject / record literally.
+  environment = [for e in concat([
     {
       name  = "STAGE"
       value = module.this.stage
@@ -210,7 +233,7 @@ module "container_php-fpm" {
     ],
     var.container_environment_php,
     local.queue_env_vars
-  )
+  ) : e if e.value != null]
   secrets = var.container_ssm_secrets_php
 
   port_mappings = [

--- a/modules/ecs-web/variables.tf
+++ b/modules/ecs-web/variables.tf
@@ -296,6 +296,12 @@ variable "ecs_task_def_track_latest" {
   default     = true
 }
 
+variable "use_deployed_image" {
+  type        = bool
+  description = "Render container images from the latest ACTIVE task definition instead of ':latest', so Terraform applies don't revert images deployed by CI/CD. Requires the task definition family to already exist; leave false for the first deployment of a new environment."
+  default     = false
+}
+
 
 
 


### PR DESCRIPTION
- Drop container environment entries whose value is null instead of
  rendering them as value: null, which ECS records literally.
- Add use_deployed_image (default false): render container images from
  the latest ACTIVE task definition instead of ':latest', so Terraform
  applies no longer register a new revision and redeploy just to revert
  the image tag CI/CD deployed. Requires the task definition family to
  exist; leave false on first deployment of a new environment.