### PR TITLE
feat(email): SES bounce/complaint/delivery webhook topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ tags
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
+.envrc
+.claude/worktrees/

--- a/modules/email/main.tf
+++ b/modules/email/main.tf
@@ -96,7 +96,7 @@ module "store_write" {
 # Bounce and Complaints notification
 
 resource "aws_ses_identity_notification_topic" "notification_topic" {
-  for_each                 = module.this.enabled ? var.notification_emails : {}
+  for_each = module.this.enabled ? var.notification_emails : {}
 
   topic_arn                = module.email_notification_topic[each.key].sns_topic_arn
   notification_type        = title(each.key)
@@ -106,7 +106,7 @@ resource "aws_ses_identity_notification_topic" "notification_topic" {
 
 module "email_notification_topic" {
   source  = "cloudposse/sns-topic/aws"
-  version = "0.20.3"
+  version = "1.2.0"
 
   for_each = var.notification_emails
 
@@ -129,6 +129,66 @@ module "email_notification_topic" {
   }
 
   context = module.this.context
+}
+
+# SES delivery-feedback webhook
+#
+# One SNS topic receives the domain identity's Bounce/Complaint/Delivery
+# notifications for forwarding to an application HTTPS webhook, which validates
+# the SNS signature and the topic ARN and confirms the subscription itself.
+# include_original_headers keeps the correlation header the app reads to map a
+# bounce back to the exact recipient and run.
+#
+# Topic creation is decoupled from the subscription so the module never forces a
+# dependency cycle. Only the subscription needs the webhook URL; the topic and
+# the SES notification wiring need just the topic ARN and the domain. A consumer
+# whose webhook URL comes from a stack that depends on this one (e.g. their web
+# module's ALB/CDN) sets webhook_topic_enabled, leaves webhook_notification_endpoint
+# empty, reads ses_webhook_topic_arn, and owns the subscription in that stack.
+# A consumer with a statically known URL passes it here and lets the module own
+# the subscription too. endpoint_auto_confirms lets the subscription reconcile to
+# "confirmed" once the app is live; a still-pending subscription does not fail the apply.
+
+locals {
+  webhook_topic_enabled        = module.this.enabled && (var.webhook_topic_enabled || var.webhook_notification_endpoint != "")
+  webhook_subscription_enabled = local.webhook_topic_enabled && var.webhook_notification_endpoint != ""
+}
+
+module "ses_webhook_topic" {
+  source  = "cloudposse/sns-topic/aws"
+  version = "1.2.0"
+
+  enabled = local.webhook_topic_enabled
+
+  name       = "ses"
+  attributes = ["webhook"]
+
+  # SES cannot publish to a topic encrypted with the default aws/sns KMS key.
+  encryption_enabled = false
+
+  allowed_aws_services_for_sns_published = [
+    "ses.amazonaws.com"
+  ]
+
+  subscribers = local.webhook_subscription_enabled ? {
+    webhook = {
+      protocol               = "https"
+      endpoint               = var.webhook_notification_endpoint
+      endpoint_auto_confirms = true
+      raw_message_delivery   = false
+    }
+  } : {}
+
+  context = module.this.context
+}
+
+resource "aws_ses_identity_notification_topic" "webhook" {
+  for_each = local.webhook_topic_enabled ? toset(var.webhook_notification_types) : []
+
+  topic_arn                = module.ses_webhook_topic.sns_topic_arn
+  notification_type        = each.value
+  identity                 = var.domain
+  include_original_headers = true
 }
 
 # DMARC

--- a/modules/email/outputs.tf
+++ b/modules/email/outputs.tf
@@ -19,7 +19,7 @@ output "spf_record" {
 }
 
 output "custom_from_domain" {
-  value = module.ses.custom_from_domain
+  value       = module.ses.custom_from_domain
   description = "The custom mail FROM domain"
 }
 
@@ -72,6 +72,11 @@ output "iam_key_id_ssm_param_arn" {
 output "iam_key_secret_ssm_param_arn" {
   value       = lookup(module.store_write.arn_map, var.iam_key_secret_ssm_param_path, "")
   description = "The SSM parameter store path where the SMTP user access key secret is stored."
+}
+
+output "ses_webhook_topic_arn" {
+  value       = try(module.ses_webhook_topic.sns_topic_arn, "")
+  description = "ARN of the SNS topic that forwards SES bounce/complaint/delivery notifications to the application webhook. Empty when the webhook is not enabled. Feed this to the app as SES_SNS_TOPIC_ARN."
 }
 
 // Verification data

--- a/modules/email/variables.tf
+++ b/modules/email/variables.tf
@@ -111,7 +111,37 @@ variable "notification_emails" {
   default     = {}
 
   validation {
-    condition = length(setunion(keys(var.notification_emails), ["bounce", "complaint", "delivery"])) == 3
+    condition     = length(setunion(keys(var.notification_emails), ["bounce", "complaint", "delivery"])) == 3
     error_message = "Only `bounce`, `complaint`, and `delivery` are allowed keys in notification_emails."
+  }
+}
+
+# SES delivery-feedback webhook
+
+variable "webhook_topic_enabled" {
+  type        = bool
+  description = "Create the SNS topic and SES bounce/complaint/delivery notification wiring and expose ses_webhook_topic_arn. Set this (with webhook_notification_endpoint empty) when the webhook URL comes from a stack that depends on this one, so that stack can own the SNS subscription without creating a dependency cycle. Implied true when webhook_notification_endpoint is set."
+  default     = false
+}
+
+variable "webhook_notification_endpoint" {
+  type        = string
+  description = "HTTPS URL of the application endpoint that receives SES bounce/complaint/delivery notifications over SNS. When set, the module also creates the topic and an https subscription to this URL. Leave empty (with webhook_topic_enabled) to have the consumer own the subscription."
+  default     = ""
+
+  validation {
+    condition     = var.webhook_notification_endpoint == "" || can(regex("^https://", var.webhook_notification_endpoint))
+    error_message = "The webhook_notification_endpoint must be an https:// URL."
+  }
+}
+
+variable "webhook_notification_types" {
+  type        = list(string)
+  description = "SES notification types published to the webhook topic."
+  default     = ["Bounce", "Complaint", "Delivery"]
+
+  validation {
+    condition     = length(setsubtract(var.webhook_notification_types, ["Bounce", "Complaint", "Delivery"])) == 0
+    error_message = "Only `Bounce`, `Complaint`, and `Delivery` are allowed in webhook_notification_types."
   }
 }


### PR DESCRIPTION
Add an optional single SNS topic that receives the domain identity's
Bounce, Complaint and Delivery notifications and forwards them to an
application HTTPS webhook. Gated on webhook_notification_endpoint; when
empty nothing is created.

The subscription uses endpoint_auto_confirms so it reconciles to
confirmed once the app is deployed with the topic ARN. Original headers
are included so the app can map a bounce to its recipient and run.

Outputs ses_webhook_topic_arn for the app's SES_SNS_TOPIC_ARN.