### PR TITLE
chore: apply terraform fmt and enable pre-commit formatting

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -35,6 +35,5 @@ actions:
   disabled:
     - trunk-announce
     - trunk-check-pre-push
-    - trunk-fmt-pre-commit
   enabled:
     - trunk-upgrade-available

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -14,10 +14,10 @@ locals {
 }
 
 resource "aws_organizations_account" "account" {
-  for_each  = var.accounts
-  name      = each.key
-  email     = format(var.account_email_format, each.key)
-  role_name = var.account_role_name
+  for_each                   = var.accounts
+  name                       = each.key
+  email                      = format(var.account_email_format, each.key)
+  role_name                  = var.account_role_name
   iam_user_access_to_billing = each.value.iam_user_access_to_billing ? "ALLOW" : "DENY"
 
   lifecycle {

--- a/modules/account/variables.tf
+++ b/modules/account/variables.tf
@@ -29,7 +29,7 @@ variable "account_role_name" {
 }
 
 variable "accounts" {
-  type        = map(object({
+  type = map(object({
     iam_user_access_to_billing = bool
   }))
   description = "Accounts to be created. Map of account names to settings."

--- a/modules/app-buckets/variables.tf
+++ b/modules/app-buckets/variables.tf
@@ -25,8 +25,8 @@ variable "buckets" {
       allowed_public_paths = optional(list(string), [])
       # S3 lifecycle configuration rules (v2) - passed through to cloudposse/s3-bucket
       lifecycle_configuration_rules = optional(list(object({
-        enabled = optional(bool, true)
-        id      = string
+        enabled                                = optional(bool, true)
+        id                                     = string
         abort_incomplete_multipart_upload_days = optional(number)
         filter_and = optional(object({
           object_size_greater_than = optional(number)

--- a/modules/app-cache-dynamodb/main.tf
+++ b/modules/app-cache-dynamodb/main.tf
@@ -1,7 +1,7 @@
 module "dynamodb_label" {
-  source     = "cloudposse/label/null"
-  version    = "0.25.0"
-  context    = module.this.context
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+  context = module.this.context
 }
 
 module "dynamodb" {

--- a/modules/betterstack-log-forwarder/main.tf
+++ b/modules/betterstack-log-forwarder/main.tf
@@ -4,7 +4,7 @@ module "log_forwarder" {
   better_stack_token       = var.better_stack_token
   better_stack_ingest_host = var.better_stack_ingest_host
 
-  timeout = var.lambda_timeout
+  timeout     = var.lambda_timeout
   memory_size = var.lambda_memory_size
 
   log_group_names = var.log_group_names

--- a/modules/certs/main.tf
+++ b/modules/certs/main.tf
@@ -15,7 +15,7 @@ locals {
   )
 
   # Produce a list of subdomains
-  subdomains = [ for subdomain in local.subdomain_set : format("%s.%s", subdomain[0], subdomain[1]) ]
+  subdomains = [for subdomain in local.subdomain_set : format("%s.%s", subdomain[0], subdomain[1])]
 }
 
 data "aws_route53_zone" "existing" {
@@ -31,6 +31,6 @@ module "acm_request_certificate" {
   process_domain_validation_options = var.auto_verify
   ttl                               = "300"
   subject_alternative_names         = local.subdomains
-  wait_for_certificate_issued = var.wait_for_certificate_issued
-  zone_name                   = data.aws_route53_zone.existing.name
+  wait_for_certificate_issued       = var.wait_for_certificate_issued
+  zone_name                         = data.aws_route53_zone.existing.name
 }

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -75,7 +75,7 @@ module "rds_instance" {
 
   engine         = var.engine
   engine_version = var.engine_version
-  
+
 
   database_name     = var.database_name
   database_user     = local.database_username
@@ -84,12 +84,12 @@ module "rds_instance" {
 
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
-  storage_type      = var.storage_type
-  allocated_storage = var.allocated_storage
+  storage_type          = var.storage_type
+  allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
-  storage_encrypted = var.storage_encrypted
+  storage_encrypted     = var.storage_encrypted
 
-  instance_class    = var.instance_class
+  instance_class = var.instance_class
 
   snapshot_identifier = var.snapshot_identifier
   deletion_protection = var.deletion_protection
@@ -111,13 +111,13 @@ module "rds_instance" {
 
   restore_to_point_in_time = var.restore_to_point_in_time
 
-  performance_insights_enabled = var.performance_insights_enabled
-  performance_insights_kms_key_id = var.performance_insights_kms_key_id
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_kms_key_id
   performance_insights_retention_period = var.performance_insights_retention_period
 
   db_parameter = var.db_parameter
-  db_options = var.db_options
-  
+  db_options   = var.db_options
+
   # db_parameter = [
   #   { name  = "myisam_sort_buffer_size"   value = "1048576" },
   #   { name  = "sort_buffer_size"          value = "2097152" }
@@ -146,27 +146,27 @@ module "rds_replica" {
   replicate_source_db = !var.promote_replica ? module.rds_instance.instance_id : null
 
   # subnet_ids          = var.subnet_ids
-  availability_zone = var.availability_zone_replica
-  vpc_id              = var.vpc_id
-  security_group_ids  = aws_security_group.allowed.*.id
+  availability_zone            = var.availability_zone_replica
+  vpc_id                       = var.vpc_id
+  security_group_ids           = aws_security_group.allowed.*.id
   associate_security_group_ids = [module.rds_instance.security_group_id]
-  ca_cert_identifier = var.ca_cert_identifier
+  ca_cert_identifier           = var.ca_cert_identifier
 
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
   dns_zone_id = var.dns_zone_id
   host_name   = var.replica_host_name
 
-  database_port     = var.database_port
+  database_port = var.database_port
 
-  storage_type      = var.storage_type
-  allocated_storage = var.allocated_storage
+  storage_type          = var.storage_type
+  allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
-  storage_encrypted = var.storage_encrypted
+  storage_encrypted     = var.storage_encrypted
 
-  instance_class    = var.instance_class
+  instance_class = var.instance_class
 
-  engine = var.engine
+  engine         = var.engine
   engine_version = var.engine_version
 
   deletion_protection = var.deletion_protection
@@ -177,10 +177,10 @@ module "rds_replica" {
   maintenance_window          = var.maintenance_window
   # AWS rejects a final snapshot when deleting a read replica; only allow one
   # if the replica has been promoted to a standalone instance
-  skip_final_snapshot         = var.promote_replica ? var.skip_final_snapshot : true
-  copy_tags_to_snapshot       = true
-  backup_retention_period     = var.backup_retention_period
-  backup_window               = var.backup_window
+  skip_final_snapshot     = var.promote_replica ? var.skip_final_snapshot : true
+  copy_tags_to_snapshot   = true
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
 
   db_parameter_group   = var.db_parameter_group
   parameter_group_name = var.parameter_group_name
@@ -190,8 +190,8 @@ module "rds_replica" {
 
   restore_to_point_in_time = var.restore_to_point_in_time
 
-  performance_insights_enabled = var.performance_insights_enabled
-  performance_insights_kms_key_id = var.performance_insights_kms_key_id
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_kms_key_id
   performance_insights_retention_period = var.performance_insights_retention_period
 
   context = module.this.context

--- a/modules/dns-delegated/variables.tf
+++ b/modules/dns-delegated/variables.tf
@@ -22,8 +22,8 @@ variable "delegated_role_name" {
 variable "zone_config" {
   description = "Zone config - a list of objects with subdomain, zone_name and dnssec_enabled keys"
   type = list(object({
-    subdomain = string
-    zone_name = string
-    dnssec_enabled    = optional(bool, false)
+    subdomain      = string
+    zone_name      = string
+    dnssec_enabled = optional(bool, false)
   }))
 }

--- a/modules/dns-primary/variables.tf
+++ b/modules/dns-primary/variables.tf
@@ -1,5 +1,5 @@
 variable "domains" {
-  type        = map(object({
+  type = map(object({
     dnssec_enabled = optional(bool, false)
   }))
   description = "Domains to set up zones for. Map of domain name to settings."

--- a/modules/ecs-event-logs/main.tf
+++ b/modules/ecs-event-logs/main.tf
@@ -1,7 +1,7 @@
 # Additional ECS event logging
 
 locals {
-    ecs_event_logs_enabled = module.this.enabled && length(var.ecs_event_logs) > 0
+  ecs_event_logs_enabled = module.this.enabled && length(var.ecs_event_logs) > 0
 }
 
 module "ecs_event_logs_label" {
@@ -17,7 +17,7 @@ module "ecs_event_logs" {
   source  = "cloudposse/cloudwatch-logs/aws"
   version = "0.6.9"
 
-  for_each = var.ecs_event_logs 
+  for_each = var.ecs_event_logs
 
   enabled = module.this.enabled && each.value.enabled
 
@@ -39,7 +39,7 @@ module "ecs_event_logs" {
 # EventBridge rule
 
 module "ecs_event_logs_cloudwatch_event" {
-  source = "cloudposse/cloudwatch-events/aws"
+  source  = "cloudposse/cloudwatch-events/aws"
   version = "0.9.0"
 
   for_each = var.ecs_event_logs
@@ -52,7 +52,7 @@ module "ecs_event_logs_cloudwatch_event" {
   cloudwatch_event_rule_pattern = {
     source      = ["aws.ecs"]
     detail-type = [each.value.detail_type]
-    detail = each.value.detail
+    detail      = each.value.detail
   }
   cloudwatch_event_target_arn = module.ecs_event_logs[each.key].log_group_arn
 

--- a/modules/ecs-event-logs/variables.tf
+++ b/modules/ecs-event-logs/variables.tf
@@ -1,8 +1,8 @@
 variable "ecs_event_logs" {
-  type        = map(object({
-    enabled          = bool
-    detail_type = string
-    detail = map(list(string))
+  type = map(object({
+    enabled           = bool
+    detail_type       = string
+    detail            = map(list(string))
     retention_in_days = optional(number, 30)
   }))
   description = "Enable logging of stopped tasks to CloudWatch Logs. This will create a CloudWatch Log Group for stopped task events."

--- a/modules/ecs-web/versions.tf
+++ b/modules/ecs-web/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 4.64.0"
     }
     github = {
-      source  = "integrations/github"
+      source = "integrations/github"
       # Temporarily limit due to bug https://github.com/integrations/terraform-provider-github/issues/2008
       version = "< 5.41.0"
     }

--- a/modules/load-balancer/variables.tf
+++ b/modules/load-balancer/variables.tf
@@ -81,13 +81,13 @@ variable "http_to_https_redirect" {
 }
 
 variable "allowed_ipv4_cidr_blocks" {
-  type        = list
+  type        = list(any)
   default     = ["0.0.0.0/0"]
   description = "IPv4 ranges allowed to access the load balancer"
 }
 
 variable "allowed_ipv6_cidr_blocks" {
-  type        = list
+  type        = list(any)
   default     = ["::/0"]
   description = "IPv6 ranges allowed to access the load balancer"
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -36,14 +36,14 @@ module "fck-nat" {
 
   for_each = var.use_fck_nat_instance_image ? module.subnets.az_public_subnets_map : {}
 
-  name                 = join("-", [module.nat-image-label.id, each.key])
-  vpc_id               = module.vpc.vpc_id
+  name   = join("-", [module.nat-image-label.id, each.key])
+  vpc_id = module.vpc.vpc_id
   # Assumes one subnet per az
-  subnet_id            = one(each.value)
+  subnet_id = one(each.value)
   # This is not the default VPC security group, but the one created by the FCK module
   use_default_security_group = true
   # Creates an ASG
-  ha_mode              = var.use_fck_nat_instance_ha_mode                 
+  ha_mode = var.use_fck_nat_instance_ha_mode
   # eip_allocation_ids   = ["eipalloc-abc1234"] # Allocation ID of an existing EIP
   use_cloudwatch_agent = false
   # When using Spot, make sure to use multiple instance types to avoid issues caused by instance type shortage
@@ -52,7 +52,7 @@ module "fck-nat" {
   instance_type = var.nat_instance_type
 
   update_route_tables = true
-  
+
   route_tables_ids = {
     # Assumes one subnet per az
     "${each.key}" = one(module.subnets.az_private_route_table_ids_map[each.key])

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -25,7 +25,7 @@ output "nat_instance_ids" {
 
 output "fck_nat_instance_arns" {
   description = "ARNs of the NAT Instances created by the FCK NAT module"
-  value       = [ for name, fck_nat in module.fck-nat : fck_nat.instance_arn ]
+  value       = [for name, fck_nat in module.fck-nat : fck_nat.instance_arn]
 }
 
 output "public_subnet_cidrs" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -3,7 +3,7 @@ variable "aws_region" {
 }
 
 variable "zones" {
-  type = list
+  type = list(any)
 }
 
 variable "account_network_cidr" {
@@ -17,8 +17,8 @@ variable "enable_nat_gateway" {
 }
 
 variable "enable_nat_instance" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enabled the NAT instance created by the Cloud Posse subnets module. Treated as `false` if `use_fck_nat_instance_image` is `true`."
 }
 
@@ -28,8 +28,8 @@ variable "nat_instance_type" {
 }
 
 variable "use_fck_nat_instance_image" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = <<EOT
     Use the FCK NAT instance image instead of the Cloud Posse NAT instance.
     
@@ -40,8 +40,8 @@ EOT
 }
 
 variable "use_fck_nat_instance_ha_mode" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = <<EOT
     Use the FCK NAT instance image in HA mode. This will create an ASG with a minimum of 2 instances.
 EOT


### PR DESCRIPTION
Run `terraform fmt -recursive` across all modules and re-enable the `trunk-fmt-pre-commit` action so formatting is enforced on future commits.

## Changes
- Reformatted 19 module `.tf` files to match `terraform fmt` output. No behaviour changes.
- Removed `trunk-fmt-pre-commit` from the disabled actions list in `.trunk/trunk.yaml`, enabling auto-format on commit. `terraform fmt` is already configured as a trunk linter.

## Test plan
`terraform fmt -recursive -check` passes clean across the repo.