### PR TITLE
ci: skip release-drafter when merge commit contains [no-release]

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ !contains(github.event.head_commit.message, '[no-release]') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a guard so a push to master does not cut a release when the merge commit message contains `[no-release]`.

The workflow runs on every push to master with `publish: true`, and release-drafter defaults to a `patch` bump. That means formatting/CI-only merges would otherwise create a new version tag. This guard lets those merges skip the release.

Merge this PR first (it must be on master to take effect, since push-triggered workflows use the workflow file from the pushed commit). Use `[no-release]` in the merge commit message when you want to skip a release.