### PR TITLE
ci: skip release on label or marker [no-release]

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,12 +10,34 @@ permissions:
 
 jobs:
   release:
-    if: ${{ !contains(github.event.head_commit.message, '[no-release]') }}
     permissions:
       contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Check for no-release signal
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '[no-release]';
+            const message = context.payload.head_commit?.message || '';
+            let skip = message.includes(marker);
+            if (!skip) {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+              });
+              skip = prs.data.some((pr) =>
+                pr.labels.some((label) => label.name === 'no-release')
+              );
+            }
+            core.setOutput('skip', skip);
+            if (skip) core.notice('no-release requested; skipping release.');
+      - name: Draft and publish release
+        if: steps.guard.outputs.skip != 'true'
+        uses: release-drafter/release-drafter@v6
         with:
           publish: true
         env:


### PR DESCRIPTION
Replace the commit-message-only guard with one that skips a release when **either** signal is present:

- the merged PR carries the `no-release` label (primary, visible in the PR UI), or
- the merge commit message contains `[no-release]` (fallback for direct pushes / hotfixes).

The job looks up the PR associated with the pushed commit and reads its labels, and also checks the head commit message.

This PR's own merge is skipped via the `[no-release]` marker in its title (the current guard on master is still commit-message-only, so the label alone would not yet be honoured on this merge). After merge, the label mechanism is live for future PRs.